### PR TITLE
afterUpdate call: fixed undefined opt

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -172,7 +172,8 @@
 					$.fn.mapael.updateElem(elemOptions, plots[id], $tooltip, animDuration);
 				}
 				
-				opt.afterUpdate && opt.afterUpdate($self, paper, areas, plots, options);
+				if( typeof opt != 'undefined' )
+					opt.afterUpdate && opt.afterUpdate($self, paper, areas, plots, options);
 			});
 			
 			// Handle resizing of the map


### PR DESCRIPTION
Hello, 

One of the two hooks introduced in the last release of Mapael is causing a type error when triggering an update. Actually when trying to execute `afterUpdate` function. The variable `opt` is undefined.
You can see it here: http://jsfiddle.net/neveldo/qGwWr/embedded/result/
I just added a line to check if the variable is defined before trigering `afterUpdate`.
