### PR TITLE
Prevent a js error when update trigger is executed

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -172,7 +172,7 @@
 					$.fn.mapael.updateElem(elemOptions, plots[id], $tooltip, animDuration);
 				}
 				
-				opt.afterUpdate && opt.afterUpdate($self, paper, areas, plots, options);
+				(typeof opt != 'undefined') && opt.afterUpdate && opt.afterUpdate($self, paper, areas, plots, options);
 			});
 			
 			// Handle resizing of the map


### PR DESCRIPTION
- opt is an optional value, then it's required to control it before to run an internal function/hook
