### PR TITLE
Use HTML from a file for Tooltips

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -327,7 +327,15 @@
 		
 		// Init the tooltip
 		if (options.tooltip && options.tooltip.content) {
-			elem.mapElem.tooltipContent = options.tooltip.content;
+			
+			if (options.tooltip.type && options.tooltip.type == "GET") {
+				$.get(options.tooltip.content, function(data){
+					elem.mapElem.tooltipContent = data;
+				});
+			} else {
+				elem.mapElem.tooltipContent = options.tooltip.content;
+			}
+			
 			$.fn.mapael.setTooltip(elem.mapElem, $tooltip);
 			
 			if (options.text && typeof options.text.content != "undefined") {


### PR DESCRIPTION
```javascript
plots: {
    'corporate': {
        latitude: 40.345713,
        longitude: -75.959424,
        tooltip: { content: "assets/corporate.php", type: "GET" },
    }
}
```

I know it could really use some error handling but that's one aspect I'm not good at.