### PR TITLE
Fix tooltip position in absolutely positioned elements

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -30,8 +30,8 @@
 		return this.each(function() {
 		
 			var $self = $(this)
-				, $tooltip = $("<div>").addClass(options.map.tooltip.cssClass).css("display", "none")
-				, $container = $("." + options.map.cssClass, this).empty().append($tooltip)
+				, $container = $("." + options.map.cssClass, this).empty()
+				, $tooltip = $("<div>").addClass(options.map.tooltip.cssClass).css("display", "none").appendTo(options.map.tooltip.target || $container)
 				, mapConf = $.fn.mapael.maps[options.map.name]
 				, paper = new Raphael($container[0], mapConf.width, mapConf.height)
 				, elemOptions = {}
@@ -1071,7 +1071,8 @@
 		map : {
 			cssClass : "map"
 			, tooltip : {
-				cssClass : "mapTooltip"
+				cssClass : "mapTooltip",
+				target: null
 			}
 			, defaultArea : {
 				attrs : {


### PR DESCRIPTION
When adding maps into absolutely positioned elements, such as bootstrap modals, the tooltip offset position is not correctly calculated.

Allowing the tooltip to be configurably placed into another dom element, such as body fixes this issue.

[View this jsfiddle](http://jsfiddle.net/mfeerick/rmutbwyu/) for example of issue: http://jsfiddle.net/mfeerick/rmutbwyu/

![image](https://cloud.githubusercontent.com/assets/371423/7537217/ddbd5cca-f58e-11e4-93e5-490672d875cd.png)


[View this jsfiddle](http://jsfiddle.net/mfeerick/s976e28u/) for example of resolution: http://jsfiddle.net/mfeerick/s976e28u/

![image](https://cloud.githubusercontent.com/assets/371423/7537289/ad512566-f58f-11e4-9f8d-eccd7160aa86.png)
