### PR TITLE
Avoid IE8 js error on map update

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -222,12 +222,12 @@
 					, elemOptions = {};
 				
 				// Reset hidden map elements (when user click on legend elements)
-				legends.forEach(function(el) {
+				$.each(legends, function(index, el) {
 					el.forEach && el.forEach(function(el) {
 						if(typeof el.hidden != "undefined" && el.hidden == true) {
 							$(el.node).trigger("click");
 						}
-					})
+					});
 				});
 				
 				if (typeof opt != "undefined") {


### PR DESCRIPTION
The variable `legends` is an array, and using `Array.prototype.forEach()` is not valid for IE8 (and maybe others?).
To fix the problem, I use `jQuery.each()` function (http://api.jquery.com/jQuery.each) which is cross-browser.

Issue doesn't appear anymore.