### PR TITLE
Usee absolute positioning for tooltip

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -56,7 +56,7 @@
 		}
 		
 		.mapTooltip {
-			position : fixed;
+			position : absolute;
 			background-color : #fff;
 			moz-opacity:0.70;
 			opacity: 0.70;

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -711,8 +711,8 @@
 						} 
 					}
 					$tooltip.css({
-						"left" : Math.min($container.offset().left + $container.width() - $tooltip.outerWidth() - 5, e.pageX + 10) - $(window).scrollLeft(),
-						"top" : Math.min($container.offset().top + $container.height() - $tooltip.outerHeight() - 5, e.pageY + 20) - $(window).scrollTop()
+						"left" : Math.min($container.width() - $tooltip.outerWidth() - 5, e.pageX - $container.offset().left + 10),
+						"top" : Math.min($container.height() - $tooltip.outerHeight() - 5, e.pageY - $container.offset().top + 20)
 					});
 				}
 				, 120
@@ -722,8 +722,8 @@
 			$tooltip.css("display", "none");
 		}).on("mousemove", function(e) {
 			$tooltip.css({
-				"left" : Math.min($container.offset().left + $container.width() - $tooltip.outerWidth() - 5, e.pageX + 10) - $(window).scrollLeft(),
-				"top" : Math.min($container.offset().top + $container.height() - $tooltip.outerHeight() - 5 , e.pageY + 20)- $(window).scrollTop()
+				"left" : Math.min($container.width() - $tooltip.outerWidth() - 5, e.pageX - $container.offset().left + 10),
+				"top" : Math.min($container.height() - $tooltip.outerHeight() - 5, e.pageY - $container.offset().top + 20)
 			});
 		});
 	};


### PR DESCRIPTION
Fixed positioning for tooltips works great on most browser.
However, it doesn't work at all in the infamous Internet Explorer 6.

Yes, I know that this browser needs to die. I know that we shouldn't try to fix it.
But I need to support it. And furthermore, the Mapael front page says 
```As Raphaël, Mapael supports Firefox 3.0+, Safari 3.0+, Chrome 5.0+, Opera 9.5+ and Internet Explorer 6.0+.```

Luckily, there is a simple solution that fixes the problem for all browsers: **using absolute positioning**.
And since absolute positioning is relative to the parent relative element, it simplifies the formula.

Also, it avoid the modal problem encounter by mfeerick. The trick to define the tooltip outside the container is not needed anymore (neveldo/jQuery-Mapael#56 should be reverted).
Here is a JSFiddle of this modal problem with this solution: http://jsfiddle.net/c9hzegpv/