### PR TITLE
Check for raphael.safari() before using it

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -1160,7 +1160,10 @@
 	$.fn.mapael.elemHover = function (paper, mapElem, textElem) {
 		mapElem.animate(mapElem.attrsHover, mapElem.attrsHover.animDuration);
 		textElem && textElem.animate(textElem.attrsHover, textElem.attrsHover.animDuration);
-		paper.safari();
+		// workaround for older version of Raphael
+		if (typeof paper.safari === "function") { 
+			paper.safari();
+		}
 	};
 	
 	/**
@@ -1172,7 +1175,10 @@
 	$.fn.mapael.elemOut = function (paper, mapElem, textElem) {
 		mapElem.animate(mapElem.originalAttrs, mapElem.attrsHover.animDuration);
 		textElem && textElem.animate(textElem.originalAttrs, textElem.attrsHover.animDuration);
-		paper.safari();
+		// workaround for older version of Raphael
+		if (typeof paper.safari === "function") { 
+			paper.safari();
+		}
 	};
 	
 	/**


### PR DESCRIPTION
The function `Raphael.safari()` seems to be removed from newer version of Raphael. Hence this fix to check for the function presence before using it.
See issue DmitryBaranovskiy/raphael#980 and comment from tomasAlabes:
```
R.safari is not part of raphael anymore [...]
```