### PR TITLE
Allow legend options to be updated

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -586,7 +586,7 @@
 			bbox = elem.mapElem.getBBox();
 
 			if (elemOptions.size || (elemOptions.width && elemOptions.height)) {
-				if (elemOptions.type == "image" || elemOptions.type == "svg") {
+				if (elemOptions.type == "image" || elemOptions.type == "svg") {
 					plotOffsetX = (elemOptions.width - bbox.width) / 2;
 					plotOffsetY = (elemOptions.height - bbox.height) / 2;
 				} else {
@@ -941,7 +941,7 @@
 				if (title) {
 					current_yCenter += title.getBBox().height;
 				}
-				if(legendType == "plot" && (typeof legendOptions.slices[i].type == "undefined" || legendOptions.slices[i].type == "circle")) {
+				if(legendType == "plot" && (typeof legendOptions.slices[i].type == "undefined" || legendOptions.slices[i].type == "circle")) {
 					current_yCenter += scale * sliceAttrs[i].r;	
 				} else {
 					current_yCenter += scale * sliceAttrs[i].height/2;

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -381,7 +381,7 @@
 				}
 				
 				// Update legends
-				$.merge(legends, Mapael.createLegends($self, options, "area", areas, 1));
+				legends = Mapael.createLegends($self, options, "area", areas, 1);
 				if (options.map.width) {
 					$.merge(legends, Mapael.createLegends($self, options, "plot", plots, (options.map.width / mapConf.width)));
     			} else {

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -380,6 +380,14 @@
 					Mapael.updateElem(elemOptions, links[id], $tooltip, animDuration);
 				}
 				
+				// Update legends
+				$.merge(legends, Mapael.createLegends($self, options, "area", areas, 1));
+				if (options.map.width) {
+					$.merge(legends, Mapael.createLegends($self, options, "plot", plots, (options.map.width / mapConf.width)));
+    			} else {
+					$.merge(legends, Mapael.createLegends($self, options, "plot", plots, ($container.width() / mapConf.width)));
+				}
+				
 				if(typeof opt != "undefined")
 					opt.afterUpdate && opt.afterUpdate($self, paper, areas, plots, options);
 			});


### PR DESCRIPTION
Legend options can now be updated in the `update` event.
```
$(".mapcontainer").trigger('update', [{
    legend : 
        area : {
            title :"Areas updated", 
            slices : [...]
        },
        plot :{
            title :"Cities updated",
            slices : [...]
        }}]);
```
Working JSFiddle: http://jsfiddle.net/60p8ukyn/1/

Related issue: neveldo/jQuery-Mapael#43