### PR TITLE
JSHint: correct missing semicolon

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -789,8 +789,12 @@
     Mapael.setEventHandlers = function(id, elemOptions, mapElem, textElem) {
         for(var event in elemOptions.eventHandlers) {
             (function(event) {
-                $(mapElem.node).on(event, function(e) {!Mapael.panning && elemOptions.eventHandlers[event](e, id, mapElem, textElem, elemOptions)});
-                textElem && $(textElem.node).on(event, function(e) {!Mapael.panning && elemOptions.eventHandlers[event](e, id, mapElem, textElem, elemOptions)});
+                $(mapElem.node).on(event, function(e) {
+                    !Mapael.panning && elemOptions.eventHandlers[event](e, id, mapElem, textElem, elemOptions);
+                });
+                textElem && $(textElem.node).on(event, function(e) {
+                    !Mapael.panning && elemOptions.eventHandlers[event](e, id, mapElem, textElem, elemOptions);
+                });
             })(event);
         }
     };


### PR DESCRIPTION
Add some linebreaks and correct JSHint warning `missing semicolon error`. (neveldo/jQuery-Mapael#89)

