### PR TITLE
JSHint: fix 'easingFunction' already exists

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -1347,11 +1347,13 @@
             , dw = w - cw
             , ch = paper._viewBox ? paper._viewBox[3] : paper.height
             , dh = h - ch
-            , easingFunction = easingFunction || "linear"
             , interval = 25
             , steps = duration / interval
             , current_step = 0
-            , easingFormula = Raphael.easing_formulas[easingFunction];
+            , easingFormula;
+
+        easingFunction = easingFunction || "linear";
+        easingFormula = Raphael.easing_formulas[easingFunction];
 
         clearInterval(Mapael.animationIntervalID);
      


### PR DESCRIPTION
Fix JSHint error `easingFunction` already exists (declared as parameter of function).
=> neveldo/jQuery-Mapael#89