### PR TITLE
JSHint: fix 'id' is unused

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -52,7 +52,6 @@
                 , areas = {}
                 , plots = {}
                 , links = {}
-                , id = 0
                 , zoomCenterX = 0
                 , zoomCenterY = 0
                 , previousPinchDist = 0;
@@ -234,7 +233,6 @@
              */
             $self.on("update", function(e, updatedOptions, newPlots, deletedPlots, opt) {
                 var i = 0
-                    , id = 0
                     , animDuration = 0
                     , elemOptions = {}
                     , showlegendElems = true;


### PR DESCRIPTION
The variable `id` is not needed anymore.
Fixes 2 warnings (neveldo/jQuery-Mapael#89)