### PR TITLE
JSHint: use dot notation

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -936,7 +936,7 @@
                     
                 sliceAttrs[i] = $.extend(
                     {}
-                    , (legendType == "plot") ? options.map["defaultPlot"].attrs : options.map["defaultArea"].attrs
+                    , (legendType == "plot") ? options.map.defaultPlot.attrs : options.map.defaultArea.attrs
                     , legendOptions.slices[i].attrs
                     , legendOptions.slices[i].legendSpecificAttrs
                 );


### PR DESCRIPTION
Fix two issues: `['xxx'] is better written in dot notation.` (neveldo/jQuery-Mapael#89)