### PR TITLE
JSHint: moved function out of loop

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -238,34 +238,34 @@
                     , animDuration = 0
                     , elemOptions = {}
                     , showlegendElems = true
-                    // This function remove a plot using animation (or not, depending on animDuration)
+                    // This function remove an element using animation (or not, depending on animDuration)
                     // Used for deletedPlots and deletedLinks
-                    , fnRemovePlot = function(plot) {
+                    , fnRemoveElement = function(elem) {
                         if (animDuration > 0) {
-                            plot.mapElem.animate({"opacity":0}, animDuration, "linear", function() {
-                                plot.mapElem.remove();
+                            elem.mapElem.animate({"opacity":0}, animDuration, "linear", function() {
+                                elem.mapElem.remove();
                             });
-                            if (plot.textElem) {
-                                plot.textElem.animate({"opacity":0}, animDuration, "linear", function() {
-                                    plot.textElem.remove();
+                            if (elem.textElem) {
+                                elem.textElem.animate({"opacity":0}, animDuration, "linear", function() {
+                                    elem.textElem.remove();
                                 });
                             }
                         } else {
-                            plot.mapElem.remove();
-                            if (plot.textElem) {
-                                plot.textElem.remove();
+                            elem.mapElem.remove();
+                            if (elem.textElem) {
+                                elem.textElem.remove();
                             }
                         }
                     }
-                    // This function show a plot or link using animation
+                    // This function show an element using animation
                     // Used for newPlots and newLinks
-                    , fnShowPlot = function(plot) {
-                        plot.mapElem.attr({opacity : 0});
-                        plot.mapElem.animate({"opacity": (typeof plot.mapElem.originalAttrs.opacity != "undefined") ? plot.mapElem.originalAttrs.opacity : 1}, animDuration);
+                    , fnShowElement = function(elem) {
+                        elem.mapElem.attr({opacity : 0});
+                        elem.mapElem.animate({"opacity": (typeof elem.mapElem.originalAttrs.opacity != "undefined") ? elem.mapElem.originalAttrs.opacity : 1}, animDuration);
 
-                        if (plot.textElem) {
-                            plot.textElem.attr({opacity : 0});
-                            plot.textElem.animate({"opacity": (typeof plot.textElem.originalAttrs.opacity != "undefined") ? plot.textElem.originalAttrs.opacity : 1}, animDuration);
+                        if (elem.textElem) {
+                            elem.textElem.attr({opacity : 0});
+                            elem.textElem.animate({"opacity": (typeof elem.textElem.originalAttrs.opacity != "undefined") ? elem.textElem.originalAttrs.opacity : 1}, animDuration);
                         }
                     };
                 

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -237,7 +237,37 @@
                     , id = 0
                     , animDuration = 0
                     , elemOptions = {}
-                    , showlegendElems = true;
+                    , showlegendElems = true
+                    // This function remove a plot using animation (or not, depending on animDuration)
+                    // Used for deletedPlots and deletedLinks
+                    , fnRemovePlot = function(plot) {
+                        if (animDuration > 0) {
+                            plot.mapElem.animate({"opacity":0}, animDuration, "linear", function() {
+                                plot.mapElem.remove();
+                            });
+                            if (plot.textElem) {
+                                plot.textElem.animate({"opacity":0}, animDuration, "linear", function() {
+                                    plot.textElem.remove();
+                                });
+                            }
+                        } else {
+                            plot.mapElem.remove();
+                            if (plot.textElem) {
+                                plot.textElem.remove();
+                            }
+                        }
+                    }
+                    // This function show a plot or link using animation
+                    // Used for newPlots and newLinks
+                    , fnShowPlot = function(plot) {
+                        plot.mapElem.attr({opacity : 0});
+                        plot.mapElem.animate({"opacity": (typeof plot.mapElem.originalAttrs.opacity != "undefined") ? plot.mapElem.originalAttrs.opacity : 1}, animDuration);
+
+                        if (plot.textElem) {
+                            plot.textElem.attr({opacity : 0});
+                            plot.textElem.animate({"opacity": (typeof plot.textElem.originalAttrs.opacity != "undefined") ? plot.textElem.originalAttrs.opacity : 1}, animDuration);
+                        }
+                    };
                 
                 // Set showlegendElems variable
                 // Keep default (true) if opt.setLegendElemsState not defined, or badly defined
@@ -258,19 +288,7 @@
                 if (typeof deletedPlots == "object") {
                     for (;i < deletedPlots.length; i++) {
                         if (typeof plots[deletedPlots[i]] != "undefined") {
-                            if (animDuration > 0) {
-                                (function(plot) {
-                                    plot.mapElem.animate({"opacity":0}, animDuration, "linear", function() {plot.mapElem.remove();});
-                                    if (plot.textElem) {
-                                        plot.textElem.animate({"opacity":0}, animDuration, "linear", function() {plot.textElem.remove();});
-                                    }
-                                })(plots[deletedPlots[i]]);
-                            } else {
-                                plots[deletedPlots[i]].mapElem.remove();
-                                if (plots[deletedPlots[i]].textElem) {
-                                    plots[deletedPlots[i]].textElem.remove();
-                                }
-                            }
+                            fnRemovePlot(plots[deletedPlots[i]]);
                             delete plots[deletedPlots[i]];
                         }
                     }
@@ -280,19 +298,7 @@
                 if (typeof opt != "undefined" && typeof opt.deletedLinks == "object") {
                     for (i = 0;i < opt.deletedLinks.length; i++) {
                         if (typeof links[opt.deletedLinks[i]] != "undefined") {
-                            if (animDuration > 0) {
-                                (function(plot) {
-                                    plot.mapElem.animate({"opacity":0}, animDuration, "linear", function() {plot.mapElem.remove();});
-                                    if (plot.textElem) {
-                                        plot.textElem.animate({"opacity":0}, animDuration, "linear", function() {plot.textElem.remove();});
-                                    }
-                                })(links[opt.deletedLinks[i]]);
-                            } else {
-                                links[opt.deletedLinks[i]].mapElem.remove();
-                                if (links[opt.deletedLinks[i]].textElem) {
-                                    links[opt.deletedLinks[i]].textElem.remove();
-                                }
-                            }
+                            fnRemovePlot(links[opt.deletedLinks[i]]);
                             delete links[opt.deletedLinks[i]];
                         }
                     }
@@ -305,13 +311,7 @@
                             options.plots[id] = newPlots[id];
                             plots[id] = Mapael.drawPlot(id, options, mapConf, paper, $tooltip);
                             if (animDuration > 0) {
-                                plots[id].mapElem.attr({opacity : 0});
-                                plots[id].mapElem.animate({"opacity": (typeof plots[id].mapElem.originalAttrs.opacity != "undefined") ? plots[id].mapElem.originalAttrs.opacity : 1}, animDuration);
-                                
-                                if (plots[id].textElem) {
-                                    plots[id].textElem.attr({opacity : 0});
-                                    plots[id].textElem.animate({"opacity": (typeof plots[id].textElem.originalAttrs.opacity != "undefined") ? plots[id].textElem.originalAttrs.opacity : 1}, animDuration);
-                                }
+                                fnShowPlot(plots[id]);
                             }
                         }
                     });
@@ -324,13 +324,7 @@
                     $.extend(options.links, opt.newLinks);
                     if (animDuration > 0) {
                         $.each(newLinks, function(id) {
-                            newLinks[id].mapElem.attr({opacity : 0});
-                            newLinks[id].mapElem.animate({"opacity": (typeof newLinks[id].mapElem.originalAttrs.opacity != "undefined") ? newLinks[id].mapElem.originalAttrs.opacity : 1}, animDuration);
-
-                            if (newLinks[id].textElem) {
-                                newLinks[id].textElem.attr({opacity : 0});
-                                newLinks[id].textElem.animate({"opacity": (typeof newLinks[id].textElem.originalAttrs.opacity != "undefined") ? newLinks[id].textElem.originalAttrs.opacity : 1}, animDuration);
-                            }
+                            fnShowPlot(newLinks[id]);
                         });
                     }
                 }


### PR DESCRIPTION
Fixes 2 JSHint warning: `Don't make functions within a loop.` (neveldo/jQuery-Mapael#89)
I found that the loop to delete the plots is quite similar to the one to delete links. Hence, I created a single function `fnRemovePlot()` which is used by each.
After that, I noticed the same pattern for the loop to show the new plots and the new links. Hence I created a new function `fnShowPlot()` which is used by both.
Code rationalization! Yiaie!