### PR TITLE
Newarch: add init() function

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -212,14 +212,20 @@
 
             // Avoid multiple instanciation
             if ($.data(this, pluginName)) throw new Error("Mapael already exists on this element.");
-            
+
             // Save instanciation on element
             // This allow external access to Mapael using $(".mapcontainer").data("mapael")
             $.data(this, pluginName, Mapael);
 
-            var $container = $(this) // the current element
+            Mapael.init(this, options);
+
+        });
+    };
+
+    Mapael.init = function(container, options) {
+            var $container = $(container) // the current element
                 , $tooltip = $("<div>").addClass(options.map.tooltip.cssClass).css("display", "none") // the tooltip container
-                , $map = $("." + options.map.cssClass, this).empty().append($tooltip) // the map container
+                , $map = $("." + options.map.cssClass, container).empty().append($tooltip) // the map container
                 , mapConf = $.fn[pluginName].maps[options.map.name]
                 , paper = new Raphael($map[0], mapConf.width, mapConf.height)
                 , elemOptions = {}
@@ -638,7 +644,7 @@
             if (options.map.afterInit) options.map.afterInit($container, paper, areas, plots, options);
 
             $(paper.desc).append(" and Mapael (http://www.vincentbroute.fr/mapael/)");
-        });
+
     };
 
     /*

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -222,6 +222,23 @@
         });
     };
 
+    /*
+     * Version number of jQuery Mapael. See http://semver.org/ for more information.
+     *  @type string
+     */
+    Mapael.version = '1.1.0';
+
+    /* zoom TimeOut handler (used to set and clear) */
+    Mapael.zoomTO = 0;
+
+    /* Panning: tell if panning action is in progress */
+    Mapael.panning = false;
+    /* Panning TimeOut handler (used to set and clear) */
+    Mapael.panningTO = 0;
+
+    /* Animate view box Interval handler (used to set and clear) */
+    Mapael.animationIntervalID = null;
+
     Mapael.init = function(container, options) {
             var $container = $(container) // the current element
                 , $tooltip = $("<div>").addClass(options.map.tooltip.cssClass).css("display", "none") // the tooltip container
@@ -648,14 +665,6 @@
     };
 
     /*
-     * Version number of jQuery Mapael. See http://semver.org/ for more information.
-     *  @type string
-     */
-    Mapael.version = '1.1.0';
-
-    Mapael.zoomTO = 0;
-
-    /*
      * Init the element "elem" on the map (drawing, setting attributes, events, tooltip, ...)
      */
     Mapael.initElem = function(paper, elem, options, $tooltip, id) {
@@ -1014,9 +1023,6 @@
             })(event);
         });
     };
-
-    Mapael.panning = false;
-    Mapael.panningTO = 0;
 
     /*
      * Init zoom and panning for the map
@@ -1575,7 +1581,6 @@
         return {};
     };
 
-    Mapael.animationIntervalID = null;
 
     /*
       * Animated view box changes

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -28,7 +28,6 @@
     
     var pluginName = "mapael";
 
-
     // Default map options
     var defaultOptions = {
         map : {
@@ -132,6 +131,7 @@
         , links : {}
     };
 
+    // Default legends option
     var legendDefaultOptions = {
         area : {
             cssClass : "areaLegend"
@@ -194,11 +194,17 @@
         }
     };
 
+    /*
+     * Mapael constructor
+     * Called directly on DOM element to apply the plugin
+     * @param options the user options
+     */
     var Mapael = function(options) {
 
-        // Extend legend default options with user options
+        // Extend default options with user options
         options = $.extend(true, {}, defaultOptions, options);
 
+        // Extend each legend default options with user options
         $.each(options.legend, function(type) {
             if ($.isArray(options.legend[type])) {
                 for (var i = 0; i < options.legend[type].length; ++i)
@@ -208,6 +214,7 @@
             }
         });
 
+        // Init the plugin on each DOM element
         return this.each(function() {
 
             // Avoid multiple instanciation
@@ -217,8 +224,8 @@
             // This allow external access to Mapael using $(".mapcontainer").data("mapael")
             $.data(this, pluginName, Mapael);
 
+            // Initialize
             Mapael.init(this, options);
-
         });
     };
 
@@ -239,6 +246,12 @@
     /* Animate view box Interval handler (used to set and clear) */
     Mapael.animationIntervalID = null;
 
+    /*
+     * Initialize the plugin
+     * Called by the constructor
+     * @param container the DOM element on which to apply the plugin
+     * @param options the complete options to use
+     */
     Mapael.init = function(container, options) {
             var $container = $(container) // the current element
                 , $tooltip = $("<div>").addClass(options.map.tooltip.cssClass).css("display", "none") // the tooltip container


### PR DESCRIPTION
This new PR introduce a separation between the Mapael constructor and a new `init()` function.
Now that the constructor take less space, we can move all the members (`version`, `zoomTO`, `panning` and so on...) on the top in order to trace them easily.

Related to neveldo/jQuery-Mapael#117.

Note: the github diff tools shows a lots of modification. Actually, there wasn't so much. The updated indentation mess everything up again. I suggest you to go through each commit ;-)