### PR TITLE
Set undefined in function param

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -22,7 +22,7 @@
         // Browser globals
         factory(jQuery, Raphael, jQuery.fn.mousewheel);
     }
-}(function ($, Raphael, mousewheel) { // jshint ignore:line
+}(function ($, Raphael, mousewheel, undefined) {
 
     "use strict";
     


### PR DESCRIPTION
This allows to:
1. Use `undefined` in our code without fearing that it's defined to something else.
2. Remove that ugly JsHint comment!
From JS Module Pattern: https://carldanley.com/js-module-pattern/

The first point is interesting, we can rewrite some check like `typeof x.y === 'undefined'` to `x.y === undefined`. And this will also be good when minimified!
However, we should keep `typeof x === 'undefined'` (i.e. check var existence) to avoid `var x doesn't exists` error message.
