### PR TITLE
Add checks for cssClass value

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -1453,7 +1453,7 @@
 
         for (var j = 0; j < legendsOptions.length; ++j) {
             // Check for class existence
-            if(legendsOptions[j].cssClass === "" || $("." + legendsOptions[j].cssClass).length === 0) {
+            if(legendsOptions[j].cssClass === "" || $("." + legendsOptions[j].cssClass, $container).length === 0) {
                 throw "The legend class `" + legendsOptions[j].cssClass + "` doesn't exists.";
             }
             if (legendsOptions[j].display === true && $.isArray(legendsOptions[j].slices) && legendsOptions[j].slices.length > 0) {

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -254,6 +254,12 @@
      * @param options the complete options to use
      */
     Mapael.init = function(container, options) {
+
+        // Init check for class existence
+        if (options.map.cssClass === "" || $("." + options.map.cssClass, container).length === 0) {
+            throw "The map class `" + options.map.cssClass + "` doesn't exists";
+        }
+
         var $container = $(container) // the current element
             , $tooltip = $("<div>").addClass(options.map.tooltip.cssClass).css("display", "none") // the tooltip container
             , $map = $("." + options.map.cssClass, container).empty().append($tooltip) // the map container
@@ -1446,6 +1452,10 @@
         }
 
         for (var j = 0; j < legendsOptions.length; ++j) {
+            // Check for class existence
+            if(legendsOptions[j].cssClass === "" || $("." + legendsOptions[j].cssClass).length === 0) {
+                throw "The legend class `" + legendsOptions[j].cssClass + "` doesn't exists.";
+            }
             if (legendsOptions[j].display === true && $.isArray(legendsOptions[j].slices) && legendsOptions[j].slices.length > 0) {
                 legends.push(Mapael.drawLegend(legendsOptions[j], $container, options, legendType, elems, scale, j));
             }


### PR DESCRIPTION
Found while working on Unit Testing.
If the `cssClass` option is set to an inexisting class, then a cryptic message from Raphael `a is unknown` is shown.
Here are some checks to avoid this issue.
No performance impacts, they are run only once at creation.