### PR TITLE
New architecture: prototype pattern

### DIFF
--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -31,7 +31,7 @@ $(function() {
         assert.equal($(".mapcontainer .map svg").attr("width"), CST_MAP_MAX_WIDTH, "Check map width size" );
         assert.equal($(".mapcontainer .map svg").attr("height"), CST_MAP_MAX_HEIGHT, "Check map height size" );
         assert.ok($(".mapcontainer").hasClass("mapael"), "Has mapael class" );
-        assert.ok(typeof $(".mapcontainer").data("mapael") === "function", "Has mapael data" );
+        assert.ok(typeof $(".mapcontainer").data("mapael") === "object", "Has mapael data" );
         assert.ok($(".mapcontainer .map .mapTooltip")[0], "Has tooltip div" );
 
     });


### PR DESCRIPTION
Implements #117

This one is huge!
Now, `$.fn.mapael` is only a lightweight function wrapper to jquery to build a new object.
`$.mapael` is now an prototype object that is instanciated on an element.
The constructor only init some internal variable and call `init()`.
The main modification is that `this` shall be use to address the *current* mapael object (and not `Mapael` anymore!). You will see that I usually assign `self` as `this` at the top of a function in order to avoid misleading name.

For the next step, there are a lot of function that can be simplify due to being in an object. For instance, a lot of internal function make use of `$container` as parameter, whereas it could simply be accessible from `self.$container`. But this will make another PR. This one is already big :)

