### PR TITLE
Expand zoom buttons functionality

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -85,3 +85,54 @@ Basically, you need to modify the prototype inside `$.mapael` instead of the old
 
 Additional note: use `$.mapael.prototype.setTooltip.call(this, ...)` to call original behavior.
 
+### D. New Zoom buttons functionnality ([#166](https://github.com/neveldo/jQuery-Mapael/issues/166))
+The zoom buttons are more curstomizable! Also, a reset buttons is now available by default.
+
+**Old options:**
+```javascript 
+zoom: {
+    enabled: false,
+    maxLevel: 10,
+    step: 0.25,
+    mousewheel: true,
+    /* Old options */
+    zoomIncssClass: "zoomIn",
+    zoomOutcssClass: "zoomOut",
+    /* - */
+    touch: true,
+    animDuration: 200,
+    animEasing: "linear"
+}
+```
+
+**New options:**
+```javascript 
+zoom: {
+    enabled: false,
+    maxLevel: 10,
+    step: 0.25,
+    mousewheel: true,
+    touch: true,
+    animDuration: 200,
+    animEasing: "linear",
+    /* New options */
+    buttons: {
+        "reset": {
+            cssClass: "zoomButton zoomReset",
+            content: "&#8226;", // bullet sign
+            title: "Reset zoom"
+        },
+        "in": {
+            cssClass: "zoomButton zoomIn",
+            content: "+",
+            title: "Zoom in"
+        },
+        "out": {
+            cssClass: "zoomButton zoomOut",
+            content: "&#8722;", // minus sign
+            title: "Zoom out"
+        }
+    }
+}
+
+

--- a/examples/advanced/dataviz_example.html
+++ b/examples/advanced/dataviz_example.html
@@ -73,32 +73,44 @@
             border-radius: 5px;
         }
 
-        .mapael .zoomIn,
-        .mapael .zoomOut {
-            background-color: #dbdbdb;
-            border: 1px solid #cfcfcf;
-            color: #161616;
-            width: 16px;
-            height: 18px;
-            line-height: 18px;
+        /* For all zoom buttons */
+        .mapael .zoomButton {
+            background-color: #fff;
+            border: 1px solid #ccc;
+            color: #000;
+            width: 15px;
+            height: 15px;
+            line-height: 15px;
             text-align: center;
             border-radius: 3px;
             cursor: pointer;
             position: absolute;
-            top: 10px;
+            top: 0;
             font-weight: bold;
             left: 10px;
 
             -webkit-user-select: none;
-        	-khtml-user-select : none;
+            -khtml-user-select : none;
             -moz-user-select: none;
-        	-o-user-select : none;
+            -o-user-select : none;
             user-select: none;
         }
 
-        .mapael .zoomOut {
-            top: 35px;
+        /* Reset Zoom button first */
+        .mapael .zoomReset {
+            top: 10px;
         }
+
+        /* Then Zoom In button */
+        .mapael .zoomIn {
+            top: 30px;
+        }
+
+        /* Then Zoom Out button */
+        .mapael .zoomOut {
+            top: 50px;
+        }
+        
     </style>
 
     <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js" charset="utf-8"></script>

--- a/examples/advanced/eventHandlers_option_and_update_event_refresh_onclick.html
+++ b/examples/advanced/eventHandlers_option_and_update_event_refresh_onclick.html
@@ -39,8 +39,8 @@
             color: #343434;
         }
 
-        .mapael .zoomIn,
-        .mapael .zoomOut {
+        /* For all zoom buttons */
+        .mapael .zoomButton {
             background-color: #fff;
             border: 1px solid #ccc;
             color: #000;
@@ -51,18 +51,30 @@
             border-radius: 3px;
             cursor: pointer;
             position: absolute;
-            top: 10px;
+            top: 0;
             font-weight: bold;
             left: 10px;
+
             -webkit-user-select: none;
-            -khtml-user-select: none;
+            -khtml-user-select : none;
             -moz-user-select: none;
-            -o-user-select: none;
+            -o-user-select : none;
             user-select: none;
         }
 
-        .mapael .zoomOut {
+        /* Reset Zoom button first */
+        .mapael .zoomReset {
+            top: 10px;
+        }
+
+        /* Then Zoom In button */
+        .mapael .zoomIn {
             top: 30px;
+        }
+
+        /* Then Zoom Out button */
+        .mapael .zoomOut {
+            top: 50px;
         }
 
         .mapael .map {

--- a/examples/advanced/initial_zoom_level_on_a_specific_position.html
+++ b/examples/advanced/initial_zoom_level_on_a_specific_position.html
@@ -42,8 +42,8 @@
             color: #343434;
         }
 
-        .mapael .zoomIn,
-        .mapael .zoomOut {
+        /* For all zoom buttons */
+        .mapael .zoomButton {
             background-color: #fff;
             border: 1px solid #ccc;
             color: #000;
@@ -54,19 +54,30 @@
             border-radius: 3px;
             cursor: pointer;
             position: absolute;
-            top: 10px;
+            top: 0;
             font-weight: bold;
             left: 10px;
 
             -webkit-user-select: none;
-            -khtml-user-select: none;
+            -khtml-user-select : none;
             -moz-user-select: none;
-            -o-user-select: none;
+            -o-user-select : none;
             user-select: none;
         }
 
-        .mapael .zoomOut {
+        /* Reset Zoom button first */
+        .mapael .zoomReset {
+            top: 10px;
+        }
+
+        /* Then Zoom In button */
+        .mapael .zoomIn {
             top: 30px;
+        }
+
+        /* Then Zoom Out button */
+        .mapael .zoomOut {
+            top: 50px;
         }
 
         .mapael .map {

--- a/examples/advanced/multiple_instances.html
+++ b/examples/advanced/multiple_instances.html
@@ -49,8 +49,8 @@
             color: #343434;
         }
 
-        .mapael .zoomIn,
-        .mapael .zoomOut {
+        /* For all zoom buttons */
+        .mapael .zoomButton {
             background-color: #fff;
             border: 1px solid #ccc;
             color: #000;
@@ -61,19 +61,30 @@
             border-radius: 3px;
             cursor: pointer;
             position: absolute;
-            top: 10px;
+            top: 0;
             font-weight: bold;
             left: 10px;
 
             -webkit-user-select: none;
-            -khtml-user-select: none;
+            -khtml-user-select : none;
             -moz-user-select: none;
-            -o-user-select: none;
+            -o-user-select : none;
             user-select: none;
         }
 
-        .mapael .zoomOut {
+        /* Reset Zoom button first */
+        .mapael .zoomReset {
+            top: 10px;
+        }
+
+        /* Then Zoom In button */
+        .mapael .zoomIn {
             top: 30px;
+        }
+
+        /* Then Zoom Out button */
+        .mapael .zoomOut {
+            top: 50px;
         }
 
         .mapael .map {

--- a/examples/advanced/update_event_for_refreshing_elements.html
+++ b/examples/advanced/update_event_for_refreshing_elements.html
@@ -38,8 +38,8 @@
             color: #343434;
         }
 
-        .mapael .zoomIn,
-        .mapael .zoomOut {
+        /* For all zoom buttons */
+        .mapael .zoomButton {
             background-color: #fff;
             border: 1px solid #ccc;
             color: #000;
@@ -50,19 +50,30 @@
             border-radius: 3px;
             cursor: pointer;
             position: absolute;
-            top: 10px;
+            top: 0;
             font-weight: bold;
             left: 10px;
 
             -webkit-user-select: none;
-            -khtml-user-select: none;
+            -khtml-user-select : none;
             -moz-user-select: none;
-            -o-user-select: none;
+            -o-user-select : none;
             user-select: none;
         }
 
-        .mapael .zoomOut {
+        /* Reset Zoom button first */
+        .mapael .zoomReset {
+            top: 10px;
+        }
+
+        /* Then Zoom In button */
+        .mapael .zoomIn {
             top: 30px;
+        }
+
+        /* Then Zoom Out button */
+        .mapael .zoomOut {
+            top: 50px;
         }
 
         .mapael .map {

--- a/examples/advanced/updates_on_links_performed.html
+++ b/examples/advanced/updates_on_links_performed.html
@@ -42,8 +42,8 @@
             color: #343434;
         }
 
-        .mapael .zoomIn,
-        .mapael .zoomOut {
+        /* For all zoom buttons */
+        .mapael .zoomButton {
             background-color: #fff;
             border: 1px solid #ccc;
             color: #000;
@@ -54,19 +54,30 @@
             border-radius: 3px;
             cursor: pointer;
             position: absolute;
-            top: 10px;
+            top: 0;
             font-weight: bold;
             left: 10px;
 
             -webkit-user-select: none;
-            -khtml-user-select: none;
+            -khtml-user-select : none;
             -moz-user-select: none;
-            -o-user-select: none;
+            -o-user-select : none;
             user-select: none;
         }
 
-        .mapael .zoomOut {
+        /* Reset Zoom button first */
+        .mapael .zoomReset {
+            top: 10px;
+        }
+
+        /* Then Zoom In button */
+        .mapael .zoomIn {
             top: 30px;
+        }
+
+        /* Then Zoom Out button */
+        .mapael .zoomOut {
+            top: 50px;
         }
     </style>
 

--- a/examples/advanced/zoom_event_on_specific_area.html
+++ b/examples/advanced/zoom_event_on_specific_area.html
@@ -38,8 +38,8 @@
             color: #343434;
         }
 
-        .mapael .zoomIn,
-        .mapael .zoomOut {
+        /* For all zoom buttons */
+        .mapael .zoomButton {
             background-color: #fff;
             border: 1px solid #ccc;
             color: #000;
@@ -50,19 +50,30 @@
             border-radius: 3px;
             cursor: pointer;
             position: absolute;
-            top: 10px;
+            top: 0;
             font-weight: bold;
             left: 10px;
 
             -webkit-user-select: none;
-            -khtml-user-select: none;
+            -khtml-user-select : none;
             -moz-user-select: none;
-            -o-user-select: none;
+            -o-user-select : none;
             user-select: none;
         }
 
-        .mapael .zoomOut {
+        /* Reset Zoom button first */
+        .mapael .zoomReset {
+            top: 10px;
+        }
+
+        /* Then Zoom In button */
+        .mapael .zoomIn {
             top: 30px;
+        }
+
+        /* Then Zoom Out button */
+        .mapael .zoomOut {
+            top: 50px;
         }
 
         .mapael .map {

--- a/examples/basic/href_areas_plotted_cities.html
+++ b/examples/basic/href_areas_plotted_cities.html
@@ -28,8 +28,8 @@
             position: relative;
         }
 
-        .mapael .zoomIn, 
-        .mapael .zoomOut {
+        /* For all zoom buttons */
+        .mapael .zoomButton {
             background-color: #fff;
             border: 1px solid #ccc;
             color: #000;
@@ -40,19 +40,30 @@
             border-radius: 3px;
             cursor: pointer;
             position: absolute;
-            top: 10px;
+            top: 0;
             font-weight: bold;
             left: 10px;
 
             -webkit-user-select: none;
-            -khtml-user-select: none;
+            -khtml-user-select : none;
             -moz-user-select: none;
-            -o-user-select: none;
+            -o-user-select : none;
             user-select: none;
         }
 
-        .mapael .zoomOut {
+        /* Reset Zoom button first */
+        .mapael .zoomReset {
+            top: 10px;
+        }
+
+        /* Then Zoom In button */
+        .mapael .zoomIn {
             top: 30px;
+        }
+
+        /* Then Zoom Out button */
+        .mapael .zoomOut {
+            top: 50px;
         }
 
         .mapael .mapTooltip {

--- a/examples/basic/legend_SVG_paths.html
+++ b/examples/basic/legend_SVG_paths.html
@@ -44,8 +44,8 @@
             color:#fff;
         }
 
-        .mapael .zoomIn,
-        .mapael .zoomOut {
+        /* For all zoom buttons */
+        .mapael .zoomButton {
             background-color: #fff;
             border: 1px solid #ccc;
             color: #000;
@@ -56,20 +56,32 @@
             border-radius: 3px;
             cursor: pointer;
             position: absolute;
-            top: 10px;
+            top: 0;
             font-weight: bold;
             left: 10px;
 
             -webkit-user-select: none;
-            -khtml-user-select: none;
+            -khtml-user-select : none;
             -moz-user-select: none;
-            -o-user-select: none;
+            -o-user-select : none;
             user-select: none;
         }
 
-        .mapael .zoomOut {
+        /* Reset Zoom button first */
+        .mapael .zoomReset {
+            top: 10px;
+        }
+
+        /* Then Zoom In button */
+        .mapael .zoomIn {
             top: 30px;
         }
+
+        /* Then Zoom Out button */
+        .mapael .zoomOut {
+            top: 50px;
+        }
+        
     </style>
 
     <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js" charset="utf-8"></script>

--- a/examples/basic/zoom_features.html
+++ b/examples/basic/zoom_features.html
@@ -30,8 +30,8 @@
             position: relative;
         }
 
-        .mapael .zoomIn,
-        .mapael .zoomOut {
+        /* For all zoom buttons */
+        .mapael .zoomButton {
             background-color: #fff;
             border: 1px solid #ccc;
             color: #000;
@@ -42,7 +42,7 @@
             border-radius: 3px;
             cursor: pointer;
             position: absolute;
-            top: 10px;
+            top: 0;
             font-weight: bold;
             left: 10px;
 
@@ -53,8 +53,19 @@
             user-select: none;
         }
 
-        .mapael .zoomOut {
+        /* Reset Zoom button first */
+        .mapael .zoomReset {
+            top: 10px;
+        }
+
+        /* Then Zoom In button */
+        .mapael .zoomIn {
             top: 30px;
+        }
+
+        /* Then Zoom Out button */
+        .mapael .zoomOut {
+            top: 50px;
         }
 
         .mapael .mapTooltip {

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -424,9 +424,9 @@
 
             // init zoom buttons
             $.each(zoomOptions.buttons, function(type, opt) {
-                var $button;
+                if (fnZoomButtons[type] === undefined) throw new Error("Unknown zoom button '" + type + "'");
                 // Create div with classes, contents and title (for tooltip)
-                $button = $("<div>").addClass(opt.cssClass)
+                var $button = $("<div>").addClass(opt.cssClass)
                                     .html(opt.content)
                                     .attr("title", opt.title);
                 // Assign click event

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -400,11 +400,20 @@
          */
         initZoom: function (mapWidth, mapHeight, zoomOptions) {
             var self = this;
-            var $zoomIn;
-            var $zoomOut;
             var mousedown = false;
             var previousX = 0;
             var previousY = 0;
+            var fnZoomButtons = {
+                "reset": function () {
+                    self.$container.trigger("zoom." + pluginName, {"level": 0});
+                },
+                "in": function () {
+                    self.$container.trigger("zoom." + pluginName, {"level": self.zoomData.zoomLevel + 1});
+                },
+                "out": function () {
+                    self.$container.trigger("zoom." + pluginName, {"level": self.zoomData.zoomLevel - 1});
+                }
+            };
 
             // init Zoom data
             $.extend(self.zoomData, {
@@ -413,16 +422,17 @@
                 panY: 0
             });
 
-            // init zoom button
-            $zoomIn = $("<div>").addClass(zoomOptions.zoomInCssClass).html("+");
-            $zoomOut = $("<div>").addClass(zoomOptions.zoomOutCssClass).html("&#x2212;");
-            self.$map.append($zoomIn).append($zoomOut);
-
-            $zoomIn.on("click." + pluginName, function () {
-                self.$container.trigger("zoom." + pluginName, {"level": self.zoomData.zoomLevel + 1});
-            });
-            $zoomOut.on("click." + pluginName, function () {
-                self.$container.trigger("zoom." + pluginName, {"level": self.zoomData.zoomLevel - 1});
+            // init zoom buttons
+            $.each(zoomOptions.buttons, function(type, opt) {
+                var $button;
+                // Create div with classes, contents and title (for tooltip)
+                $button = $("<div>").addClass(opt.cssClass)
+                                    .html(opt.content)
+                                    .attr("title", opt.title);
+                // Assign click event
+                $button.on("click." + pluginName, fnZoomButtons[type]);
+                // Append to map
+                self.$map.append($button);
             });
 
             // Update the zoom level of the map on mousewheel
@@ -1852,12 +1862,27 @@
                     enabled: false,
                     maxLevel: 10,
                     step: 0.25,
-                    zoomInCssClass: "zoomIn",
-                    zoomOutCssClass: "zoomOut",
                     mousewheel: true,
                     touch: true,
                     animDuration: 200,
-                    animEasing: "linear"
+                    animEasing: "linear",
+                    buttons: {
+                        "reset": {
+                            cssClass: "zoomButton zoomReset",
+                            content: "&#8226;", // bullet sign
+                            title: "Reset zoom"
+                        },
+                        "in": {
+                            cssClass: "zoomButton zoomIn",
+                            content: "+",
+                            title: "Zoom in"
+                        },
+                        "out": {
+                            cssClass: "zoomButton zoomOut",
+                            content: "&#8722;", // minus sign
+                            title: "Zoom out"
+                        }
+                    }
                 }
             },
             legend: {


### PR DESCRIPTION
Implements #166 and add some customization to zoom buttons ! 

The default options now looks like this: for each buttons, a cssClass, content and title is provided.

```javascript 
defaultOptions: {
    map: {
        zoom: {
            /* ... */
            /* removed zoomIncssClass & zoomOutcssClass */
            /* ... */
            buttons: {
                "reset": {
                    cssClass: "zoomButton zoomReset",
                    content: "&#8226;", // bullet sign
                    title: "Reset zoom"
                },
                "in": {
                    cssClass: "zoomButton zoomIn",
                    content: "+",
                    title: "Zoom in"
                },
                "out": {
                    cssClass: "zoomButton zoomOut",
                    content: "&#8722;", // minus sign
                    title: "Zoom out"
                }
            }
        }
    }
}
```

Note: at the beginning, I though about adding a complete HTML tooltip like in the map, but title attribute was quite sufficient for this task.