### PR TITLE
Bower naming convention

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "neveldo/jQuery-Mapael",
+  "name": "jquery-mapael",
   "version": "1.1.0",
   "main": "./js/jquery.mapael.js",
   "description": "jQuery Mapael is a jQuery plugin based on raphael.js that allows you to display dynamic vector maps.",


### PR DESCRIPTION
http://bower.io/docs/creating-packages/#register

"Bower doesn’t support GitHub-style namespacing (org/repo), however you are encouraged to namespace related packages with -, for example, angular- and paper-."

I'm waiting to see how bower.io/search react to this update for jquery-knob  :/