### PR TITLE
Implements relative zoom for onZoom

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -412,10 +412,10 @@
                     self.$container.trigger("zoom." + pluginName, {"level": 0});
                 },
                 "in": function () {
-                    self.$container.trigger("zoom." + pluginName, {"level": self.zoomData.zoomLevel + 1});
+                    self.$container.trigger("zoom." + pluginName, {"level": "+1"});
                 },
                 "out": function () {
-                    self.$container.trigger("zoom." + pluginName, {"level": self.zoomData.zoomLevel - 1});
+                    self.$container.trigger("zoom." + pluginName, {"level": -1});
                 }
             };
 
@@ -586,15 +586,39 @@
          */
         onZoomEvent: function (e, zoomOptions) {
             var self = this;
-            var newLevel = Math.min(Math.max(zoomOptions.level, 0), self.options.map.zoom.maxLevel);
+            var newLevel = 0;
             var panX = 0;
             var panY = 0;
             var previousZoomLevel = (1 + self.zoomData.zoomLevel * self.options.map.zoom.step);
-            var zoomLevel = (1 + newLevel * self.options.map.zoom.step);
+            var zoomLevel = 0;
             var animDuration = (zoomOptions.animDuration !== undefined) ? zoomOptions.animDuration : self.options.map.zoom.animDuration;
             var offsetX = 0;
             var offsetY = 0;
             var coords = {};
+
+            // Get user defined zoom level
+            if (typeof zoomOptions.level === "string") {
+                // level is a string, either "n", "+n" or "-n"
+                if ((zoomOptions.level.slice(0, 1) === '+') || (zoomOptions.level.slice(0, 1) === '-')) {
+                    // zoomLevel is relative
+                    newLevel = self.zoomData.zoomLevel + parseInt(zoomOptions.level);
+                } else {
+                    // zoomLevel is absolute
+                    newLevel = parseInt(zoomOptions.level);
+                }
+            } else {
+                // level is integer
+                if (zoomOptions.level < 0) {
+                    // zoomLevel is relative
+                    newLevel = self.zoomData.zoomLevel + zoomOptions.level;
+                } else {
+                    // zoomLevel is absolute
+                    newLevel = zoomOptions.level;
+                }
+            }
+            // Make sure we stay in the boundaries
+            newLevel = Math.min(Math.max(newLevel, 0), self.options.map.zoom.maxLevel);
+            zoomLevel = (1 + newLevel * self.options.map.zoom.step);
 
             if (zoomOptions.latitude !== undefined && zoomOptions.longitude !== undefined) {
                 coords = self.mapConf.getCoords(zoomOptions.latitude, zoomOptions.longitude);
@@ -1891,7 +1915,7 @@
                 }, interval
             );
         },
-        
+
         /*
           * Check for Raphael bug regarding drawing while beeing hidden (under display:none)
           * See https://github.com/neveldo/jQuery-Mapael/issues/135


### PR DESCRIPTION
Se #160 for discussion

The `level` value now accepts:
- **positive integer value** (0, 1, 2 ... n): zoom to absolute level n (actual behavior)
- **string `"+n"`**: relative zoom of -n
- **string `"-n"`**, or **negative integer value**: relative zoom of -n