### PR TITLE
Feature/add code coverage info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .fuse_hidden*
 .idea
 /node_modules
+.coverage-results

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - "4.1"
 before_script:
   - npm install -g grunt-cli
+after_success: grunt coveralls

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,13 +25,30 @@ module.exports = function(grunt) {
             }
         },
         qunit: {
-            all: ['test/index.html']
+            all: {
+                options: {
+                    urls: ['test/index.html?coverage=true&lcovReport']
+                }
+            }
+        },
+        coveralls: {
+            options: {
+                force: true
+            },
+            all: {
+                src: '.coverage-results/core.lcov',
+            }
         }
+    });
+
+    grunt.event.on('qunit.report', function(data) {
+        grunt.file.write('.coverage-results/core.lcov', data);
     });
 
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-qunit');
     grunt.loadNpmTasks('grunt-contrib-uglify');
+    grunt.loadNpmTasks('grunt-coveralls');
 
     grunt.registerTask('test', ['jshint', 'qunit']);
     grunt.registerTask('build', ['uglify']);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jQuery Mapael - Dynamic vector maps
 
-[![Build Status](https://travis-ci.org/neveldo/jQuery-Mapael.svg?branch=master)](https://travis-ci.org/neveldo/jQuery-Mapael)
+[![Build Status](https://travis-ci.org/neveldo/jQuery-Mapael.svg?branch=master)](https://travis-ci.org/neveldo/jQuery-Mapael) [![Coverage Status](https://coveralls.io/repos/neveldo/jQuery-Mapael/badge.svg?branch=master&service=github)](https://coveralls.io/github/neveldo/jQuery-Mapael?branch=master)
 
 The complete documentation is available on [Mapael website](http://www.vincentbroute.fr/mapael) (repository:  ['neveldo/mapael-documentation'](https://github.com/neveldo/mapael-documentation)).
 

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -2140,8 +2140,25 @@
 
     };
 
+    var loadedMaps = {}, loadedLegacyMaps = {};
+
+    // Keep references to jQuery.mapael.maps / jQuery.fn.mapael.maps objects if they exist
+    if ($[pluginName] !== undefined && $[pluginName].maps !== undefined) {
+        loadedMaps = $[pluginName].maps;
+    }
+    if ($.fn[pluginName] !== undefined && $.fn[pluginName].maps !== undefined) {
+        loadedLegacyMaps = $[pluginName].maps;
+    }
+
     // Extend jQuery with Mapael
     $[pluginName] = Mapael;
+
+    // Prevent from empty jQuery.mapael.maps object if mapael script is (re)loaded after the maps 
+    if ($[pluginName].maps === undefined) {
+        $[pluginName].maps = {};
+    }
+    $.extend($[pluginName].maps, loadedMaps, loadedLegacyMaps);
+
     // Add jQuery DOM function
     $.fn[pluginName] = function (options) {
         // Call Mapael on each element

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -2142,22 +2142,9 @@
 
     var loadedMaps = {}, loadedLegacyMaps = {};
 
-    // Keep references to jQuery.mapael.maps / jQuery.fn.mapael.maps objects if they exist
-    if ($[pluginName] !== undefined && $[pluginName].maps !== undefined) {
-        loadedMaps = $[pluginName].maps;
-    }
-    if ($.fn[pluginName] !== undefined && $.fn[pluginName].maps !== undefined) {
-        loadedLegacyMaps = $[pluginName].maps;
-    }
-
     // Extend jQuery with Mapael
-    $[pluginName] = Mapael;
-
-    // Prevent from empty jQuery.mapael.maps object if mapael script is (re)loaded after the maps 
-    if ($[pluginName].maps === undefined) {
-        $[pluginName].maps = {};
-    }
-    $.extend($[pluginName].maps, loadedMaps, loadedLegacyMaps);
+    if ($[pluginName] === undefined) $[pluginName] = {};
+    $.extend(true, $[pluginName], Mapael);
 
     // Add jQuery DOM function
     $.fn[pluginName] = function (options) {

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -2140,8 +2140,6 @@
 
     };
 
-    var loadedMaps = {}, loadedLegacyMaps = {};
-
     // Extend jQuery with Mapael
     if ($[pluginName] === undefined) $[pluginName] = {};
     $.extend(true, $[pluginName], Mapael);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.11.3",
     "grunt-contrib-qunit": "~0.7.0",
-    "grunt-contrib-uglify": "~0.9.2"
+    "grunt-contrib-uglify": "~0.9.2",
+    "grunt-coveralls": "~1.0.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -5,6 +5,10 @@ if (location.href.match(/(\?|&)lcovReport($|&|=)/)) {
 
    // send results to PhantomJS
    QUnit.done(function() {
-      alert(JSON.stringify(['qunit.report', window._$blanket_LCOV]));
+        var data = JSON.stringify(['qunit.report', window._$blanket_LCOV]);
+
+        // Fix for coveralls "Fatal error: ENOENT, no such file or directory"
+        data = data.replace("file://", "");
+        alert(data);
    });
 }

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -1,0 +1,10 @@
+// LCOV reporter, only if called with "lcovReport" parameter
+if (location.href.match(/(\?|&)lcovReport($|&|=)/)) {
+   blanket.options("reporter", "https://rawgit.com/alex-seville/blanket/v1.1.7/src/reporters/lcov_reporter.js");
+   blanket.options("reporter_options", { toHTML:false });
+
+   // send results to PhantomJS
+   QUnit.done(function() {
+      alert(JSON.stringify(['qunit.report', window._$blanket_LCOV]));
+   });
+}

--- a/test/index.html
+++ b/test/index.html
@@ -25,13 +25,14 @@
     </style>
 
     <script src="http://code.jquery.com/qunit/qunit-1.20.0.js" charset="utf-8"></script>
+    <script src="https://rawgit.com/alex-seville/blanket/v1.1.7/dist/qunit/blanket.min.js" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sinon.js/1.15.4/sinon.min.js" charset="utf-8"></script>
 
     <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js" charset="utf-8"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js" charset="utf-8"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/raphael/2.1.4/raphael-min.js" charset="utf-8"></script>
 
-    <script src="../js/jquery.mapael.js" charset="utf-8"></script>
+    <script src="../js/jquery.mapael.js" charset="utf-8" data-cover></script>
     <script src="../js/maps/france_departments.js" charset="utf-8"></script>
     <script src="../js/maps/world_countries.js" charset="utf-8"></script>
     <script src="../js/maps/usa_states.js" charset="utf-8"></script>
@@ -42,6 +43,7 @@
     <script src="test-areas.js" charset="utf-8"></script>
     <script src="test-plots.js" charset="utf-8"></script>
     <script src="test-range.js" charset="utf-8"></script>
+    <script src="coverage.js" charset="utf-8"></script>
 
 </head>
 


### PR DESCRIPTION
Added code coverage info for unit tests.

The update on jquery.mapael.js (https://github.com/neveldo/jQuery-Mapael/commit/0ab57800973d5fa7799e14dbbfbd951ef59cf6af) is needed because blanketjs load jquery.mapael.js a second time through a XHR request , but I'm not very fond of this modification ...

Don't know why, but in the lcov report, the path to the source file begins with `file://`, so it seems to look for a relative file and throws a not found error : https://github.com/neveldo/jQuery-Mapael/commit/1977e0372602b529995ceb8fa664aaf50e336cc2 . Removing `file://` from the path solve the issue for now, but maybe we should fix properly this issue.

I have mostly followed this tutorial : http://www.strangeplanet.fr/blog/dev/use-travis-ci-coveralls-for-a-web-frontend-library