### PR TITLE
bring element to front

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -1180,11 +1180,16 @@
             var plotOffsetX;
             var plotOffsetY;
 
+            elem.mapElem.toFront();
+
             if (elemOptions.value !== undefined)
                 elem.value = elemOptions.value;
 
             // Update the label
             if (elem.textElem) {
+
+                elem.textElem.toFront();
+
                 if (elemOptions.text !== undefined && elemOptions.text.content !== undefined && elemOptions.text.content != elem.textElem.attrs.text)
                     elem.textElem.attr({text: elemOptions.text.content});
 
@@ -1802,10 +1807,12 @@
         elemOut: function (mapElem, textElem) {
             var self = this;
             // Set mapElem
+            mapElem.toFront();
             if (mapElem.attrsHover.animDuration > 0) mapElem.animate(mapElem.originalAttrs, mapElem.attrsHover.animDuration);
             else mapElem.attr(mapElem.originalAttrs);
             // Set textElem
             if (textElem) {
+                textElem.toFront();
                 if (textElem.attrsHover.animDuration > 0) textElem.animate(textElem.originalAttrs, textElem.attrsHover.animDuration);
                 else textElem.attr(textElem.originalAttrs);
             }


### PR DESCRIPTION
 bring element to front on hover in case a transform requires it to move on top of another element like with scale or translate. otherwise countries were getting covered up by their neighbors.