### PR TITLE
Fix text position on mouseover

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -168,6 +168,18 @@
             if (self.options.map.tooltip.css) self.$tooltip.css(self.options.map.tooltip.css);
             self.paper.setViewBox(0, 0, self.mapConf.width, self.mapConf.height, false);
 
+            // Handle map size
+            if (self.options.map.width) {
+                // NOT responsive: map has a fixed width
+                self.paper.setSize(self.options.map.width, self.mapConf.height * (self.options.map.width / self.mapConf.width));
+
+                // Create the legends for plots taking into account the scale of the map
+                self.createLegends("plot", self.plots, (self.options.map.width / self.mapConf.width));
+            } else {
+                // Responsive: handle resizing of the map
+                self.handleMapResizing();
+            }
+
             // Draw map areas
             $.each(self.mapConf.elems, function (id) {
                 var elemOptions = self.getElemOptions(
@@ -229,18 +241,6 @@
             self.$container.on("showElementsInRange." + pluginName, function (e, opt) {
                 self.onShowElementsInRange(e, opt);
             });
-
-            // Handle map size
-            if (self.options.map.width) {
-                // NOT responsive: map has a fixed width
-                self.paper.setSize(self.options.map.width, self.mapConf.height * (self.options.map.width / self.mapConf.width));
-
-                // Create the legends for plots taking into account the scale of the map
-                self.createLegends("plot", self.plots, (self.options.map.width / self.mapConf.width));
-            } else {
-                // Responsive: handle resizing of the map
-                self.handleMapResizing();
-            }
 
             // Hook that allows to add custom processing on the map
             if (self.options.map.afterInit) self.options.map.afterInit(self.$container, self.paper, self.areas, self.plots, self.options);


### PR DESCRIPTION
Fix issue #203 : On mouseout on an element that has a text next to it, the related text moves vertically a few pixel away from its original position.

It fixes the issue after map initialisation, but it still occurs if the map size is updated after the initialisation.