### PR TITLE
Fix : always call setHoverOptions() for element initialisation

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -369,13 +369,15 @@
             // Set user event handlers
             if (elemOptions.eventHandlers) self.setEventHandlers(id, elemOptions, elem.mapElem, elem.textElem);
 
+            // Set hover option for mapElem
+            self.setHoverOptions(elem.mapElem, elemOptions.attrs, elemOptions.attrsHover);
+
+            // Set hover option for textElem
+            if (elem.textElem) self.setHoverOptions(elem.textElem, elemOptions.text.attrs, elemOptions.text.attrsHover);
+
             // Set hover behavior only if attrsHover is set for area or for text
             if (($.isEmptyObject(elemOptions.attrsHover) === false) ||
                 (elem.textElem && $.isEmptyObject(elemOptions.text.attrsHover) === false)) {
-                // Set hover option for mapElem
-                self.setHoverOptions(elem.mapElem, elemOptions.attrs, elemOptions.attrsHover);
-                // Set hover option for textElem
-                if (elem.textElem) self.setHoverOptions(elem.textElem, elemOptions.text.attrs, elemOptions.text.attrsHover);
                 // Set hover behavior
                 self.setHover(elem.mapElem, elem.textElem);
             }


### PR DESCRIPTION
setHoverOptions() should be called for elements and text elements even if attrsHover is an empty object. Indeed, setHoverOptions() also init element.originalAttrs. element.originalAttrs is used for instance in the legend : when a user click on an item of the legend to re-show the related elements on the map, it will make use of originalAttrs.