### PR TITLE
Set Mapael version outside of prototype

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -118,12 +118,6 @@
      * Each mapael object inherits their properties and methods from this prototype
      */
     Mapael.prototype = {
-
-        /*
-         * Version number
-         */
-        version: version,
-
         /*
          * Initialize the plugin
          * Called by the constructor
@@ -2305,6 +2299,10 @@
 
     };
 
+    // Mapael version number
+    // Accessible as $.mapael.version
+    Mapael.version = version;
+    
     // Extend jQuery with Mapael
     if ($[pluginName] === undefined) $[pluginName] = Mapael;
 


### PR DESCRIPTION
Wow, it's been quite a time since my last PR...!
I wish I could help you more.

Following #78 I opened almost 2 years ago (!)
You correctly implemented the fix, but the switching to v2.0 with prototypes made the version access not easy at all.
At that time, I didn't check...

I copied how Datatable is handling its version number (https://github.com/DataTables/DataTables/blob/master/media/js/jquery.dataTables.js#L9416)

That way, the version is accessible as $.mapael.version