### PR TITLE
Add Github ISSUE and PULLREQUEST templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+
+Before submitting a new issue, please search on the issue tracker first (https://github.com/neveldo/jQuery-Mapael/issues)
+
+
+## Description
+<!--- Describe what you want to achieve -->
+<!--- Provide a working example if possible (e.g. using JSFiddle https://jsfiddle.net/) -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Environment
+<!--- Include all relevant details about your environment -->
+* Mapael version:
+* Raphael version:
+* Browser Name and version:
+* Operating System and version (desktop or mobile):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+
+Hey! Thanks for submitting a pull request! 
+
+
+Are you adding a new map? Additionnal maps shall be added to the mapael-maps repository (https://github.com/neveldo/mapael-maps)
+
+
+Before submitting, please check the existing Pull Requests (https://github.com/neveldo/jQuery-Mapael/pulls).
+
+For new feature, please provide a working example (e.g. using JSFiddle https://jsfiddle.net/)
+
+For more information, see the `CONTRIBUTING` guide.
+


### PR DESCRIPTION
Implements templates for GH to guides users when opening new issues or PR.
See https://help.github.com/articles/creating-an-issue-template-for-your-repository

I used https://github.com/stevemao/github-issue-templates/blob/master/simple/ISSUE_TEMPLATE.md as inspiration.

Maybe we should add something about being respectful?