### PR TITLE
init elem falling back to default cssClass if not specified

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -420,8 +420,12 @@
             }
 
             if (elemOptions.cssClass !== undefined) {
-                $(elem.mapElem.node).addClass(elemOptions.cssClass);
-            }
+                if (elemOptions.cssClass) {
+                    $(elem.mapElem.node).addClass(elemOptions.cssClass);
+                }
+                else if (self.options.map.defaultArea.cssClass !== undefined) {
+                    $(elem.mapElem.node).addClass(self.options.map.defaultArea.cssClass);
+                }
 
             $(elem.mapElem.node).attr("data-id", id);
         },


### PR DESCRIPTION
After the pull request from @Indigo744 I started noticing other issues. It appears that if I don't have updates enabled, the default cssClass does not get assigned if not overridden. I stuck with the same format, and added a condition so if nothing is passed through the init event for the cssClass, it falls back to the default (assuming it is there). 

I haven't ever actually minified js outside of an application, so I wasn't sure how to do it. Sorry.