### PR TITLE
Zoom animation: use requestAnimationFrame where possible

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -2106,7 +2106,7 @@
         },
 
         /*
-         * requestAnimationFrame polyfill
+         * requestAnimationFrame/cancelAnimationFrame polyfill
          * Based on https://gist.github.com/jlmakes/47eba84c54bc306186ac1ab2ffd336d4
          * and also https://gist.github.com/paulirish/1579671
          *
@@ -2114,7 +2114,16 @@
          * But requestAnimationFrame and cancelAnimationFrame shall be called since
          * in order to be in window context
          */
+        // The function to use for requestAnimationFrame
+        requestAnimationFrame: function(callback) {
+            return this._requestAnimationFrameFn.call(window, callback);
+        },
+        // The function to use for cancelAnimationFrame
+        cancelAnimationFrame: function(id) {
+            this._cancelAnimationFrameFn.call(window, id);
+        },
         // The requestAnimationFrame polyfill'd function
+        // Value set by self-invoking function, will be run only once
         _requestAnimationFrameFn: (function () {
             var polyfill = (function () {
                 var clock = (new Date()).getTime();
@@ -2122,16 +2131,20 @@
                 return function (callback) {
                     var currentTime = (new Date()).getTime();
 
+                    // requestAnimationFrame strive to run @60FPS
+                    // (e.g. every 16 ms)
                     if (currentTime - clock > 16) {
                         clock = currentTime;
                         callback(currentTime);
                     } else {
+                        // Ask browser to schedule next callback when possible
                         return setTimeout(function () {
                             polyfill(callback);
                         }, 0);
                     }
                 };
             })();
+
             return window.requestAnimationFrame ||
                 window.webkitRequestAnimationFrame ||
                 window.mozRequestAnimationFrame ||
@@ -2139,11 +2152,8 @@
                 window.oRequestAnimationFrame ||
                 polyfill;
         })(),
-        // The function to use for requestAnimationFrame
-        requestAnimationFrame: function(callback) {
-            return this._requestAnimationFrameFn.call(window, callback);
-        },
         // The CancelAnimationFrame polyfill'd function
+        // Value set by self-invoking function, will be run only once
         _cancelAnimationFrameFn: (function () {
             return window.cancelAnimationFrame ||
                 window.webkitCancelAnimationFrame ||
@@ -2156,10 +2166,6 @@
                 window.oCancelRequestAnimationFrame ||
                 clearTimeout;
         })(),
-        // The function to use for cancelAnimationFrame
-        cancelAnimationFrame: function(id) {
-            this._cancelAnimationFrameFn.call(window, id);
-        },
 
         /*
          * SetViewBox wrapper
@@ -2390,7 +2396,7 @@
     // Mapael version number
     // Accessible as $.mapael.version
     Mapael.version = version;
-    
+
     // Extend jQuery with Mapael
     if ($[pluginName] === undefined) $[pluginName] = Mapael;
 


### PR DESCRIPTION
I updated the Zoom animation related code to implements requestAnimationFrame where possible.
For older browser, it should fall back to setTimeout.

For more information on rAF: 
 - http://codetonics.com/javascript/requestanimationframe/ 
 - https://stackoverflow.com/a/38709924 
 - and of course MDN https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame

On my way, I've updated the code to no longer use the `paper._viewBox` which rely on Raphael internal var. This internal var or naming may be moved or renamed in the future, and is not sustainable.
So I simply made a wrapper for `paper.setViewBox()` that tracks the current viewBox values.

Regarding the `animateViewBox()` implementation, the main change regards the way the steps and ratio are defined.

Before, a constant was used (25 ms) for computer the number of steps (and was used for the setInterval timer). Will it (kind of) works, this approach could not work here since the requestAnimationFrame has a period of 16ms minimum (to match 60 FPS) but may vary depending on the browser load and screen refresh rate (and painting time). Hence, the proper approach in these case is to track the elapsed time, and compute the current ratio based on this.

Furthermore, it appears that the setViewBox call triggers a repainting of the whole SVG, which can take between 20ms and 50ms on my desktop computer. Hence why using a fixed step (25 ms) was not a reliable solution and computer the step depending on time is a better approach.