### PR TITLE
Fix: custom event handler on text element

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -500,7 +500,7 @@
                 self.$container.off(fullEventName).on(fullEventName, "[data-id]", function (e) {
                     var $elem = $(this);
                     var id = $elem.attr('data-id');
-                    var type = $elem.attr('data-type');
+                    var type = $elem.attr('data-type').replace('-text', '');
 
                     if (!self.panning &&
                         self.customEventHandlers[eventName][type] !== undefined &&

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -313,6 +313,7 @@
             self.areas = undefined;
             self.plots = undefined;
             self.links = undefined;
+            self.customEventHandlers = undefined;
         },
 
         handleMapResizing: function () {


### PR DESCRIPTION
PR #319 (event delegation) introduced a regression regarding custom event handlers.

Text element did no longer trigger the element custom handler.

This PR fixes this issue.