### PR TITLE
Update event filtering TimeOut 

### DIFF
--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -76,9 +76,6 @@
         // Panning: tell if panning action is in progress
         self.panning = false;
 
-        // Panning TimeOut handler (used to set and clear)
-        self.panningTO = 0;
-
         // Animate view box
         self.zoomAnimID = null; // Interval handler (used to set and clear)
         self.zoomAnimStartTime = null; // Animation start time
@@ -684,14 +681,20 @@
             });
 
             // Panning
+            var panningMouseUpTO = null;
+            var panningMouseMoveTO = null;
             $("body").on("mouseup." + pluginName + (zoomOptions.touch ? " touchend." + pluginName : ""), function () {
                 mousedown = false;
-                setTimeout(function () {
+                clearTimeout(panningMouseUpTO);
+                clearTimeout(panningMouseMoveTO);
+                panningMouseUpTO = setTimeout(function () {
                     self.panning = false;
                 }, self.panningEndFilteringTO);
             });
 
             self.$map.on("mousedown." + pluginName + (zoomOptions.touch ? " touchstart." + pluginName : ""), function (e) {
+                clearTimeout(panningMouseUpTO);
+                clearTimeout(panningMouseMoveTO);
                 if (e.pageX !== undefined) {
                     mousedown = true;
                     previousX = e.pageX;
@@ -707,6 +710,9 @@
                 var currentLevel = self.zoomData.zoomLevel;
                 var pageX = 0;
                 var pageY = 0;
+
+                clearTimeout(panningMouseUpTO);
+                clearTimeout(panningMouseMoveTO);
 
                 if (e.pageX !== undefined) {
                     pageX = e.pageX;
@@ -735,8 +741,7 @@
                         });
                         self.setViewBox(panX, panY, self.currentViewBox.w, self.currentViewBox.h);
 
-                        clearTimeout(self.panningTO);
-                        self.panningTO = setTimeout(function () {
+                        panningMouseMoveTO = setTimeout(function () {
                             self.$map.trigger("afterPanning", {
                                 x1: panX,
                                 y1: panY,

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -127,6 +127,23 @@
      * Each mapael object inherits their properties and methods from this prototype
      */
     Mapael.prototype = {
+
+        /* Filtering TimeOut value in ms
+         * Used for mouseover trigger over elements */
+        MouseOverFilteringTO: 120,
+        /* Filtering TimeOut value in ms
+         * Used for afterPanning trigger when panning */
+        panningFilteringTO: 150,
+        /* Filtering TimeOut value in ms
+         * Used for mouseup/touchend trigger when panning */
+        panningEndFilteringTO: 50,
+        /* Filtering TimeOut value in ms
+         * Used for afterZoom trigger when zooming */
+        zoomFilteringTO: 150,
+        /* Filtering TimeOut value in ms
+         * Used for when resizing window */
+        resizeFilteringTO: 150,
+
         /*
          * Initialize the plugin
          * Called by the constructor
@@ -327,7 +344,7 @@
                 // setTimeout to wait for the user to finish its resizing
                 self.resizeTO = setTimeout(function () {
                     self.$map.trigger("resizeEnd");
-                }, 150);
+                }, self.resizeFilteringTO);
             };
 
             // Attach resize handler
@@ -416,7 +433,7 @@
                             self.elemEnter(self.legends[legendIndex].elems[id]);
                         }
                     }
-                }, 120);
+                }, self.MouseOverFilteringTO);
             });
 
             /* Attach mousemove event delegation
@@ -675,7 +692,7 @@
                 mousedown = false;
                 setTimeout(function () {
                     self.panning = false;
-                }, 50);
+                }, self.panningEndFilteringTO);
             });
 
             self.$map.on("mousedown." + pluginName + (zoomOptions.touch ? " touchstart." + pluginName : ""), function (e) {
@@ -730,7 +747,7 @@
                                 x2: (panX + self.currentViewBox.w),
                                 y2: (panY + self.currentViewBox.h)
                             });
-                        }, 150);
+                        }, self.panningFilteringTO);
 
                         previousX = pageX;
                         previousY = pageY;
@@ -926,7 +943,7 @@
                         x2: panX + panWidth,
                         y2: panY + panHeight
                     });
-                }, 150);
+                }, self.zoomFilteringTO);
             }
 
             $.extend(self.zoomData, {


### PR DESCRIPTION
3 modifications:

1. Define all filtering TimeOut values in the prototype for easy override
2. Simplify the resize handler (the `resizeEnd` event was not needed)
3. Moves `resizeTO` and `panningTO` to inner function to avoid clutering the `this` namespace.

