### PR TITLE
Fix 'clicked' legend element behavior

### DIFF
--- a/examples/advanced/legend_show_hide.html
+++ b/examples/advanced/legend_show_hide.html
@@ -89,7 +89,8 @@
                                 attrs: {
                                     fill: "#2579b5"
                                 },
-                                label: "Between 10 millions and 50 millions inhabitants"
+                                label: "Between 10 millions and 50 millions inhabitants",
+                                clicked: true
                             },
                             {
                                 min: 50000000,
@@ -101,8 +102,8 @@
                         ]
                     },
                     plot: {
-                        title: "Cities population"
-                        , slices: [
+                        title: "Cities population",
+                        slices: [
                             {
                                 max: 500000,
                                 attrs: {
@@ -138,7 +139,8 @@
                                     "stroke-width": 1
                                 },
                                 label: "More than 1 million inhabitants",
-                                size: 30
+                                size: 30,
+                                clicked: true
                             }
                         ]
                     }

--- a/examples/basic/legend_SVG_paths.html
+++ b/examples/basic/legend_SVG_paths.html
@@ -81,7 +81,7 @@
         .mapael .zoomOut {
             top: 50px;
         }
-        
+
     </style>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js" charset="utf-8"></script>
@@ -124,7 +124,8 @@
                             height: 30,
                             attrs: {
                                 fill: "#8AD12C"
-                            }
+                            },
+                            clicked: true
                         }, {
                             label: "Value 2",
                             sliceValue: "Value 2",

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -185,18 +185,6 @@
             if (self.options.map.tooltip.css) self.$tooltip.css(self.options.map.tooltip.css);
             self.setViewBox(0, 0, self.mapConf.width, self.mapConf.height);
 
-            // Handle map size
-            if (self.options.map.width) {
-                // NOT responsive: map has a fixed width
-                self.paper.setSize(self.options.map.width, self.mapConf.height * (self.options.map.width / self.mapConf.width));
-
-                // Create the legends for plots taking into account the scale of the map
-                self.createLegends("plot", self.plots, (self.options.map.width / self.mapConf.width));
-            } else {
-                // Responsive: handle resizing of the map
-                self.initResponsiveSize();
-            }
-
             // Draw map areas
             $.each(self.mapConf.elems, function (id) {
                 // Init area object
@@ -228,6 +216,18 @@
                 self.plots[id] = self.drawPlot(id);
             });
 
+            // Handle map size
+            if (self.options.map.width) {
+                // NOT responsive: map has a fixed width
+                self.paper.setSize(self.options.map.width, self.mapConf.height * (self.options.map.width / self.mapConf.width));
+
+                // Create the legends for plots taking into account the scale of the map
+                self.createLegends("plot", self.plots, (self.options.map.width / self.mapConf.width));
+            } else {
+                // Responsive: handle resizing of the map
+                self.initResponsiveSize();
+            }
+            
             // Attach zoom event
             self.$container.on("zoom." + pluginName, function (e, zoomOptions) {
                 self.onZoomEvent(e, zoomOptions);

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -185,6 +185,18 @@
             if (self.options.map.tooltip.css) self.$tooltip.css(self.options.map.tooltip.css);
             self.setViewBox(0, 0, self.mapConf.width, self.mapConf.height);
 
+            // Handle map size
+            if (self.options.map.width) {
+                // NOT responsive: map has a fixed width
+                self.paper.setSize(self.options.map.width, self.mapConf.height * (self.options.map.width / self.mapConf.width));
+
+                // Create the legends for plots taking into account the scale of the map
+                self.createLegends("plot", self.plots, (self.options.map.width / self.mapConf.width));
+            } else {
+                // Responsive: handle resizing of the map
+                self.initResponsiveSize();
+            }
+
             // Draw map areas
             $.each(self.mapConf.elems, function (id) {
                 // Init area object
@@ -216,18 +228,6 @@
                 self.plots[id] = self.drawPlot(id);
             });
 
-            // Handle map size
-            if (self.options.map.width) {
-                // NOT responsive: map has a fixed width
-                self.paper.setSize(self.options.map.width, self.mapConf.height * (self.options.map.width / self.mapConf.width));
-
-                // Create the legends for plots taking into account the scale of the map
-                self.createLegends("plot", self.plots, (self.options.map.width / self.mapConf.width));
-            } else {
-                // Responsive: handle resizing of the map
-                self.initResponsiveSize();
-            }
-            
             // Attach zoom event
             self.$container.on("zoom." + pluginName, function (e, zoomOptions) {
                 self.onZoomEvent(e, zoomOptions);

--- a/js/jquery.mapael.js
+++ b/js/jquery.mapael.js
@@ -189,9 +189,6 @@
             if (self.options.map.width) {
                 // NOT responsive: map has a fixed width
                 self.paper.setSize(self.options.map.width, self.mapConf.height * (self.options.map.width / self.mapConf.width));
-
-                // Create the legends for plots taking into account the scale of the map
-                self.createLegends("plot", self.plots, (self.options.map.width / self.mapConf.width));
             } else {
                 // Responsive: handle resizing of the map
                 self.initResponsiveSize();
@@ -248,6 +245,9 @@
 
             // Create the legends for areas
             self.createLegends("area", self.areas, 1);
+
+            // Create the legends for plots taking into account the scale of the map
+            self.createLegends("plot", self.plots, self.paper.width / self.mapConf.width);
 
             // Attach update event
             self.$container.on("update." + pluginName, function (e, opt) {
@@ -341,7 +341,8 @@
                     self.paper.setSize(containerWidth, self.mapConf.height * newScale);
 
                     // Create plots legend again to take into account the new scale
-                    if (isInit || self.options.legend.redrawOnResize) {
+                    // Do not do this on init (it will be done later)
+                    if (isInit !== true && self.options.legend.redrawOnResize) {
                         self.createLegends("plot", self.plots, newScale);
                     }
                 }


### PR DESCRIPTION
Fix https://github.com/neveldo/jQuery-Mapael/issues/349 .

The 'clicked' option is handled through a handleClickOnLegendElem() call within drawLegend() function.

However, the legend creation precede the areas and plots creation, so the 'clicked' option can't be handled properly. (however, it's weird, because it seems to work with areas, but not with plots ...)

I have moved the "Handle map size" part (which include legends creation) right after the creation of the areas, plots & links. It seems there is no side effect.

Before : http://jsfiddle.net/neveldo/sckgyLyr/
After : http://jsfiddle.net/neveldo/adbr8u7L/